### PR TITLE
Custom Tags, Automatic 360, Caching changes

### DIFF
--- a/AudicaMod/src/DiffCalculationUtil.cs
+++ b/AudicaMod/src/DiffCalculationUtil.cs
@@ -13,7 +13,7 @@ internal static class DiffCalculatorUtil
             for (int i = 0; i < songIDs.Count; i++)
             {
                 var songData = SongList.I.GetSong(songIDs[i]);
-                var calc = new DifficultyCalculator(songData);
+                var calc = SongBrowser.DiffCache.getDifficultyCalculations(songData);
                 if (calc.expert != null) file.WriteLine($"{SongBrowser.RemoveFormatting(songData.artist).Replace(",", "")} - {SongBrowser.RemoveFormatting(songData.title).Replace(",", "")}," +
                     "Expert," +
                     $"{calc.expert.difficultyRating.ToString("n2")}," +
@@ -40,7 +40,7 @@ internal static class DiffCalculatorUtil
 
     public static void LogCurrentSongDifficulty()
     {
-        var calc = new DifficultyCalculator(SongDataHolder.I.songData);
+        var calc = SongBrowser.DiffCache.getDifficultyCalculations(SongDataHolder.I.songData);
         MelonLogger.Log("\n" + calc.songID);
         if (calc.expert != null) MelonLogger.Log("\nExpert: " + calc.expert.difficultyRating.ToString());
         if (calc.advanced != null) MelonLogger.Log("\nAdvanced: " + calc.advanced.difficultyRating.ToString());

--- a/AudicaMod/src/DiffCalculationUtil.cs
+++ b/AudicaMod/src/DiffCalculationUtil.cs
@@ -13,7 +13,7 @@ internal static class DiffCalculatorUtil
             for (int i = 0; i < songIDs.Count; i++)
             {
                 var songData = SongList.I.GetSong(songIDs[i]);
-                var calc = SongBrowser.DiffCache.getDifficultyCalculations(songData);
+                var calc = new DifficultyCalculator(songData);
                 if (calc.expert != null) file.WriteLine($"{SongBrowser.RemoveFormatting(songData.artist).Replace(",", "")} - {SongBrowser.RemoveFormatting(songData.title).Replace(",", "")}," +
                     "Expert," +
                     $"{calc.expert.difficultyRating.ToString("n2")}," +
@@ -40,7 +40,7 @@ internal static class DiffCalculatorUtil
 
     public static void LogCurrentSongDifficulty()
     {
-        var calc = SongBrowser.DiffCache.getDifficultyCalculations(SongDataHolder.I.songData);
+        var calc = new DifficultyCalculator(SongDataHolder.I.songData);
         MelonLogger.Log("\n" + calc.songID);
         if (calc.expert != null) MelonLogger.Log("\nExpert: " + calc.expert.difficultyRating.ToString());
         if (calc.advanced != null) MelonLogger.Log("\nAdvanced: " + calc.advanced.difficultyRating.ToString());

--- a/AudicaMod/src/DifficultyCalculator.cs
+++ b/AudicaMod/src/DifficultyCalculator.cs
@@ -7,7 +7,7 @@ public class DifficultyCalculator
 {
     public string songID;
 
-    public static Dictionary<string, float> calculatorCache = new Dictionary<string, float>();
+    public static Dictionary<string, (float value, bool is360)> calculatorCache = new Dictionary<string, (float value, bool is360)>();
 
     public CalculatedDifficulty expert;
     public CalculatedDifficulty advanced;
@@ -21,47 +21,51 @@ public class DifficultyCalculator
         EvaluateDifficulties(songData);
     }
 
-    public static float GetRating(string songID, string difficulty)
+    public static (float value, bool is360) GetRating(string songID, string difficulty)
     {
         var songData = SongList.I.GetSong(songID);
         var diffLower = difficulty.ToLower();
         if (calculatorCache.ContainsKey(songID + diffLower)) return calculatorCache[songID + diffLower];
         else
         {
-            if (songData == null) return 0f;
+            if (songData == null) return (0f,false);
             var calc = new DifficultyCalculator(songData);
             switch (diffLower)
             {
                 case "easy":
                     if (calc.beginner != null)
                     {
-                        calculatorCache.Add(songID + diffLower, calc.beginner.difficultyRating);
-                        return calc.beginner.difficultyRating;
+                        (float value, bool is360) data = (calc.beginner.difficultyRating, calc.beginner.is360);
+                        calculatorCache.Add(songID + diffLower, data);
+                        return data;
                     }
-                    else return 0f;
+                    else return (0f, false);
                 case "normal":
                     if (calc.standard != null)
                     {
-                        calculatorCache.Add(songID + diffLower, calc.standard.difficultyRating);
-                        return calc.standard.difficultyRating;
+                        (float value, bool is360) data = (calc.standard.difficultyRating, calc.standard.is360);
+                        calculatorCache.Add(songID + diffLower, data);
+                        return data;
                     }
-                    else return 0f;
+                    else return (0f, false);
                 case "hard":
                     if (calc.advanced != null)
                     {
-                        calculatorCache.Add(songID + diffLower, calc.advanced.difficultyRating);
-                        return calc.advanced.difficultyRating;
+                        (float value, bool is360) data = (calc.advanced.difficultyRating, calc.advanced.is360);
+                        calculatorCache.Add(songID + diffLower, data);
+                        return (0f, false);
                     }
-                    else return 0f;
+                    else return (0f, false);
                 case "expert":
                     if (calc.expert != null)
                     {
-                        calculatorCache.Add(songID + diffLower, calc.expert.difficultyRating);
-                        return calc.expert.difficultyRating;
+                        (float value, bool is360) data = (calc.expert.difficultyRating, calc.expert.is360);
+                        calculatorCache.Add(songID + diffLower, data);
+                        return (0f, false);
                     }
-                    else return 0f;
+                    else return (0f, false);
                 default:
-                    return 0f;
+                    return (0f, false);
             }
         }
 

--- a/AudicaMod/src/DifficultyCalculator.cs
+++ b/AudicaMod/src/DifficultyCalculator.cs
@@ -1,37 +1,13 @@
-﻿using AudicaModding;
-using Il2CppSystem;
+﻿using Il2CppSystem;
 using MelonLoader;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-
-public class DifficultyCache
-{
-    private Dictionary<string, DifficultyCalculator> cachedDifficultyCalculations = new Dictionary<string, DifficultyCalculator>();
-
-    public bool songCached(string songID)
-    {
-        return cachedDifficultyCalculations.ContainsKey(songID);
-    }
-
-    public DifficultyCalculator getDifficultyCalculations(SongList.SongData songData)
-    {
-        if(songCached(songData.songID))
-        {
-            return cachedDifficultyCalculations[songData.songID];
-        }
-        else
-        {
-            DifficultyCalculator diff = new DifficultyCalculator(songData);
-            cachedDifficultyCalculations[songData.songID] = diff;
-            return diff;
-        }
-    }
-}
 
 public class DifficultyCalculator
 {
     public string songID;
+
+    public static Dictionary<string, float> calculatorCache = new Dictionary<string, float>();
 
     public CalculatedDifficulty expert;
     public CalculatedDifficulty advanced;
@@ -48,26 +24,47 @@ public class DifficultyCalculator
     public static float GetRating(string songID, string difficulty)
     {
         var songData = SongList.I.GetSong(songID);
-        if (songData == null) return 0f;
-        var calc = SongBrowser.DiffCache.getDifficultyCalculations(songData);
         var diffLower = difficulty.ToLower();
-        switch (diffLower)
+        if (calculatorCache.ContainsKey(songID + diffLower)) return calculatorCache[songID + diffLower];
+        else
         {
-            case "easy":
-                if (calc.beginner != null) return calc.beginner.difficultyRating;
-                else return 0f;
-            case "normal":
-                if (calc.standard != null) return calc.standard.difficultyRating;
-                else return 0f;
-            case "hard":
-                if (calc.advanced != null) return calc.advanced.difficultyRating;
-                else return 0f;
-            case "expert":
-                if (calc.expert != null) return calc.expert.difficultyRating;
-                else return 0f;
-            default:
-                return 0f;
+            if (songData == null) return 0f;
+            var calc = new DifficultyCalculator(songData);
+            switch (diffLower)
+            {
+                case "easy":
+                    if (calc.beginner != null)
+                    {
+                        calculatorCache.Add(songID + diffLower, calc.beginner.difficultyRating);
+                        return calc.beginner.difficultyRating;
+                    }
+                    else return 0f;
+                case "normal":
+                    if (calc.standard != null)
+                    {
+                        calculatorCache.Add(songID + diffLower, calc.standard.difficultyRating);
+                        return calc.standard.difficultyRating;
+                    }
+                    else return 0f;
+                case "hard":
+                    if (calc.advanced != null)
+                    {
+                        calculatorCache.Add(songID + diffLower, calc.advanced.difficultyRating);
+                        return calc.advanced.difficultyRating;
+                    }
+                    else return 0f;
+                case "expert":
+                    if (calc.expert != null)
+                    {
+                        calculatorCache.Add(songID + diffLower, calc.expert.difficultyRating);
+                        return calc.expert.difficultyRating;
+                    }
+                    else return 0f;
+                default:
+                    return 0f;
+            }
         }
+
     }
 
     public float GetRatingFromKataDifficulty(KataConfig.Difficulty difficulty)
@@ -128,7 +125,7 @@ public class CalculatedDifficulty
 
         //autodetect 360
         is360 = (Math.Abs(cueExtremesX.highest - cueExtremesX.lowest) >= 20);
-        
+
     }
 
     public static Dictionary<Target.TargetBehavior, float> objectDifficultyModifier = new Dictionary<Target.TargetBehavior, float>()
@@ -209,7 +206,7 @@ public class CalculatedDifficulty
 
     void CalculateDensity()
     {
-        density = (float) allCues.Count / length;
+        density = (float)allCues.Count / length;
     }
 
     private void GetSpacingPerHand(List<SongCues.Cue> cues)

--- a/AudicaMod/src/Hooks.cs
+++ b/AudicaMod/src/Hooks.cs
@@ -230,17 +230,20 @@ namespace AudicaModding
                     }
 
                     //add 360 tag
-                    DifficultyCalculator calc = SongBrowser.DiffCache.getDifficultyCalculations(song);
+                    (float value, bool is360) easy = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Easy.ToString());
+                    (float value, bool is360) normal = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Normal.ToString());
+                    (float value, bool is360) hard = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Hard.ToString());
+                    (float value, bool is360) expert = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Expert.ToString());
 
-                    if (song.hasEasy && calc.beginner.is360) songd.customEasyTags.Insert(0, "360");
+                    if (song.hasEasy && easy.is360) songd.customEasyTags.Insert(0, "360");
 
-                    if (song.hasNormal && calc.standard.is360) songd.customStandardTags.Insert(0, "360");
-
-
-                    if (song.hasHard && calc.advanced.is360) songd.customAdvancedTags.Insert(0, "360");
+                    if (song.hasNormal && normal.is360) songd.customStandardTags.Insert(0, "360");
 
 
-                    if (song.hasExpert && calc.expert.is360) songd.customExpertTags.Insert(0, "360");
+                    if (song.hasHard && hard.is360) songd.customAdvancedTags.Insert(0, "360");
+
+
+                    if (song.hasExpert && expert.is360) songd.customExpertTags.Insert(0, "360");
 
                     songd.customExpertTags = songd.customExpertTags.Distinct().ToList();
                     songd.customStandardTags = songd.customStandardTags.Distinct().ToList();

--- a/AudicaMod/src/Hooks.cs
+++ b/AudicaMod/src/Hooks.cs
@@ -6,6 +6,7 @@ using MelonLoader;
 using Valve.VR.InteractionSystem;
 using TMPro;
 using System.Linq;
+using static DifficultyCalculator;
 
 namespace AudicaModding
 {
@@ -229,21 +230,23 @@ namespace AudicaModding
                         songd = SongBrowser.SongDisplayPackage.FillCustomData(songd, song.songID);
                     }
 
+                    
+                    CachedCalculation easy = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Easy.ToString());
+                    CachedCalculation normal = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Normal.ToString());
+                    CachedCalculation hard = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Hard.ToString());
+                    CachedCalculation expert = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Expert.ToString());
+
+                    //add mine tag if there are mines
+                    if (song.hasEasy && easy.hasMines) songd.customEasyTags.Insert(0, "Mines");
+                    if (song.hasNormal && normal.hasMines) songd.customStandardTags.Insert(0, "Mines");
+                    if (song.hasHard && hard.hasMines) songd.customAdvancedTags.Insert(0, "Mines");
+                    if (song.hasExpert && expert.hasMines) songd.customExpertTags.Insert(0, "Mines");
+
                     //add 360 tag
-                    (float value, bool is360) easy = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Easy.ToString());
-                    (float value, bool is360) normal = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Normal.ToString());
-                    (float value, bool is360) hard = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Hard.ToString());
-                    (float value, bool is360) expert = DifficultyCalculator.GetRating(song.songID, KataConfig.Difficulty.Expert.ToString());
-
                     if (song.hasEasy && easy.is360) songd.customEasyTags.Insert(0, "360");
-
                     if (song.hasNormal && normal.is360) songd.customStandardTags.Insert(0, "360");
-
-
                     if (song.hasHard && hard.is360) songd.customAdvancedTags.Insert(0, "360");
-
-
-                    if (song.hasExpert && expert.is360) songd.customExpertTags.Insert(0, "360");
+                    if (song.hasExpert && expert.is360) songd.customExpertTags.Insert(0, "360");         
 
                     songd.customExpertTags = songd.customExpertTags.Distinct().ToList();
                     songd.customStandardTags = songd.customStandardTags.Distinct().ToList();

--- a/AudicaMod/src/Hooks.cs
+++ b/AudicaMod/src/Hooks.cs
@@ -5,6 +5,7 @@ using System;
 using MelonLoader;
 using Valve.VR.InteractionSystem;
 using TMPro;
+using System.Linq;
 
 namespace AudicaModding
 {
@@ -222,11 +223,29 @@ namespace AudicaModding
                     songd.hasAdvanced = song.hasHard;
                     songd.hasExpert = song.hasExpert;
 
-                    //if song data loader is installed look for 360 tag
+                    //if song data loader is installed look for custom tags
                     if (SongBrowser.songDataLoaderInstalled)
                     {
-                        songd = SongBrowser.SongDisplayPackage.Fill360Data(songd, song.songID);
+                        songd = SongBrowser.SongDisplayPackage.FillCustomData(songd, song.songID);
                     }
+
+                    //add 360 tag
+                    DifficultyCalculator calc = SongBrowser.DiffCache.getDifficultyCalculations(song);
+
+                    if (song.hasEasy && calc.beginner.is360) songd.customEasyTags.Insert(0, "360");
+
+                    if (song.hasNormal && calc.standard.is360) songd.customStandardTags.Insert(0, "360");
+
+
+                    if (song.hasHard && calc.advanced.is360) songd.customAdvancedTags.Insert(0, "360");
+
+
+                    if (song.hasExpert && calc.expert.is360) songd.customExpertTags.Insert(0, "360");
+
+                    songd.customExpertTags = songd.customExpertTags.Distinct().ToList();
+                    songd.customStandardTags = songd.customStandardTags.Distinct().ToList();
+                    songd.customAdvancedTags = songd.customAdvancedTags.Distinct().ToList();
+                    songd.customEasyTags = songd.customEasyTags.Distinct().ToList();
 
                     entry.item.mapperLabel.text += SongBrowser.GetDifficultyString(songd);  
                 }

--- a/AudicaMod/src/SongBrowser.cs
+++ b/AudicaMod/src/SongBrowser.cs
@@ -46,8 +46,6 @@ namespace AudicaModding
 
         //Meeps' Stuff
         public static bool songDataLoaderInstalled = false;
-
-        public static DifficultyCache DiffCache = new DifficultyCache();
         public class SongDisplayPackage
         {
             public bool hasEasy = false;

--- a/AudicaMod/src/SongBrowser.cs
+++ b/AudicaMod/src/SongBrowser.cs
@@ -46,6 +46,8 @@ namespace AudicaModding
 
         //Meeps' Stuff
         public static bool songDataLoaderInstalled = false;
+
+        public static DifficultyCache DiffCache = new DifficultyCache();
         public class SongDisplayPackage
         {
             public bool hasEasy = false;
@@ -53,38 +55,35 @@ namespace AudicaModding
             public bool hasAdvanced = false;
             public bool hasExpert = false;
 
-            //360 tag
-            public bool easy360 = false;
-            public bool standard360 = false;
-            public bool advanced360 = false;
-            public bool expert360 = false;
+            public List<string> customEasyTags = new List<string>();
+            public List<string> customStandardTags = new List<string>();
+            public List<string> customAdvancedTags = new List<string>();
+            public List<string> customExpertTags = new List<string>();
 
-            public static SongDisplayPackage Fill360Data(SongDisplayPackage songd, string songID)
+            public static SongDisplayPackage FillCustomData(SongDisplayPackage songd, string songID)
             {
                 if (SongDataLoader.AllSongData.ContainsKey(songID))
                 {
                     SongDataLoader.SongData currentSong = SongDataLoader.AllSongData[songID];
                     if (currentSong.HasCustomData())
                     {
-                        if (currentSong.SongHasCustomDataKey("easy360"))
+                        if (currentSong.SongHasCustomDataKey("customEasyTags"))
                         {
-                            songd.easy360 = currentSong.GetCustomData<bool>("easy360");
+                            songd.customEasyTags = currentSong.GetCustomData<List<string>>("customEasyTags");                           
+                        }
+                        if (currentSong.SongHasCustomDataKey("customStandardTags"))
+                        {
+                            songd.customStandardTags = currentSong.GetCustomData<List<string>>("customStandardTags");
+                        }
+                        if (currentSong.SongHasCustomDataKey("customAdvancedTags"))
+                        {
+                            songd.customAdvancedTags = currentSong.GetCustomData<List<string>>("customAdvancedTags");
+                        }
+                        if (currentSong.SongHasCustomDataKey("customExpertTags"))
+                        {
+                            songd.customExpertTags = currentSong.GetCustomData<List<string>>("customExpertTags");
                         }
 
-                        if (currentSong.SongHasCustomDataKey("standard360"))
-                        {
-                            songd.standard360 = currentSong.GetCustomData<bool>("standard360");
-                        }
-
-                        if (currentSong.SongHasCustomDataKey("advanced360"))
-                        {
-                            songd.advanced360 = currentSong.GetCustomData<bool>("advanced360");
-                        }
-
-                        if (currentSong.SongHasCustomDataKey("expert360"))
-                        {
-                            songd.expert360 = currentSong.GetCustomData<bool>("expert360");
-                        }
                     }
                 }
                 return songd;
@@ -359,10 +358,10 @@ namespace AudicaModding
         public static string GetDifficultyString(SongDisplayPackage songD)
         {
             return "[" +
-                (songD.hasEasy ? "<color=#54f719>B</color>" : "") + (songD.hasEasy && songD.easy360 ? "<color=#32a8a4>(360) </color>" : "") +
-                (songD.hasStandard ? "<color=#19d2f7>S</color>" : "") + (songD.hasStandard && songD.standard360 ? "<color=#32a8a4> (360) </color>" : "") +
-                (songD.hasAdvanced ? "<color=#f7a919>A</color>" : "") + (songD.advanced360 && songD.hasAdvanced ? "<color=#32a8a4> (360) </color>" : "") +
-                (songD.hasExpert ? "<color=#b119f7>E</color>" : "") + (songD.hasExpert && songD.expert360 ? "<color=#32a8a4> (360)</color>" : "") +
+                (songD.hasEasy ? "<color=#54f719>B</color>" : "") + (songD.hasEasy && (songD.customEasyTags.Count) > 0 ? "<color=#54f719>(" + songD.customEasyTags.ToArray<string>().Join() + ") </color>" : "") +
+                (songD.hasStandard ? "<color=#19d2f7>S</color>" : "") + (songD.hasStandard && (songD.customStandardTags.Count) > 0 ? "<color=#19d2f7> (" + songD.customStandardTags.ToArray<string>().Join() + ") </color>" : "") +
+                (songD.hasAdvanced ? "<color=#f7a919>A</color>" : "") + (songD.hasAdvanced && (songD.customAdvancedTags.Count) > 0 ? "<color=#f7a919> (" + songD.customAdvancedTags.ToArray<string>().Join() + ") </color>" : "") +
+                (songD.hasExpert ? "<color=#b119f7>E</color>" : "") + (songD.hasExpert && (songD.customExpertTags.Count) > 0 ? "<color=#b119f7> (" + songD.customExpertTags.ToArray<string>().Join() + ")</color>" : "") +
                 "]";
         }
 

--- a/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
+++ b/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
@@ -129,7 +129,7 @@ internal static class ScoreHistory
                 if (noFail) return;
                 if (percent < 30f) return;
                 float maxScorePercent = (float)score / (float)StarThresholds.I.GetMaxRawScore(songID, difficulty);
-                (float value, bool is360) difficultyRating = DifficultyCalculator.GetRating(songID, difficulty.ToString());
+                DifficultyCalculator.CachedCalculation difficultyRating = DifficultyCalculator.GetRating(songID, difficulty.ToString());
                 AddScore(songID, score, maxScorePercent, difficultyRating.value, ScoreKeeper.I.mStreak, ScoreKeeper.I.mMaxStreak, difficulty); 
             }
             counter++;

--- a/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
+++ b/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
@@ -129,7 +129,7 @@ internal static class ScoreHistory
                 if (noFail) return;
                 if (percent < 30f) return;
                 float maxScorePercent = (float)score / (float)StarThresholds.I.GetMaxRawScore(songID, difficulty);
-                float difficultyRating = SongBrowser.DiffCache.getDifficultyCalculations(SongList.I.GetSong(songID)).GetRatingFromKataDifficulty(difficulty);
+                float difficultyRating = DifficultyCalculator.GetRating(songID, difficulty.ToString());
                 AddScore(songID, score, maxScorePercent, difficultyRating, ScoreKeeper.I.mStreak, ScoreKeeper.I.mMaxStreak, difficulty); 
             }
             counter++;

--- a/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
+++ b/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
@@ -129,7 +129,7 @@ internal static class ScoreHistory
                 if (noFail) return;
                 if (percent < 30f) return;
                 float maxScorePercent = (float)score / (float)StarThresholds.I.GetMaxRawScore(songID, difficulty);
-                float difficultyRating = new DifficultyCalculator(SongList.I.GetSong(songID)).GetRatingFromKataDifficulty(difficulty);
+                float difficultyRating = SongBrowser.DiffCache.getDifficultyCalculations(SongList.I.GetSong(songID)).GetRatingFromKataDifficulty(difficulty);
                 AddScore(songID, score, maxScorePercent, difficultyRating, ScoreKeeper.I.mStreak, ScoreKeeper.I.mMaxStreak, difficulty); 
             }
             counter++;

--- a/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
+++ b/AudicaMod/src/UI/AudicaScore/AudicaScore.cs
@@ -47,7 +47,7 @@ public class CalculatedScoreEntry
         this.songID = localScore.songID;
         this.maxScorePercent = localScore.maxScorePercent;
         this.audicaPointsWeighted = 0f;
-        this.audicaPointsRaw = DifficultyCalculator.GetRating(songID, localScore.difficultyString) * maxScorePercent * 30;
+        this.audicaPointsRaw = DifficultyCalculator.GetRating(songID, localScore.difficultyString).value * maxScorePercent * 30;
     }
 }
 [Serializable]
@@ -129,8 +129,8 @@ internal static class ScoreHistory
                 if (noFail) return;
                 if (percent < 30f) return;
                 float maxScorePercent = (float)score / (float)StarThresholds.I.GetMaxRawScore(songID, difficulty);
-                float difficultyRating = DifficultyCalculator.GetRating(songID, difficulty.ToString());
-                AddScore(songID, score, maxScorePercent, difficultyRating, ScoreKeeper.I.mStreak, ScoreKeeper.I.mMaxStreak, difficulty); 
+                (float value, bool is360) difficultyRating = DifficultyCalculator.GetRating(songID, difficulty.ToString());
+                AddScore(songID, score, maxScorePercent, difficultyRating.value, ScoreKeeper.I.mStreak, ScoreKeeper.I.mMaxStreak, difficulty); 
             }
             counter++;
         }

--- a/AudicaMod/src/UI/AudicaScore/DifficultyDisplay.cs
+++ b/AudicaMod/src/UI/AudicaScore/DifficultyDisplay.cs
@@ -1,6 +1,7 @@
 ﻿
 using AudicaModding;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 
@@ -58,41 +59,41 @@ internal static class DifficultyDisplay
 
     private struct fillData
     {
-        public string easyAdditions;
-        public string standardAdditions;
-        public string advancedAdditions;
-        public string expertAdditions;
+        public List<string> easyAdditions;
+        public List<string> standardAdditions;
+        public List<string> advancedAdditions;
+        public List<string> expertAdditions;
     }
     //could be used for other info in the future
-    public static string CreateDisplayStringAdditions(SongDataLoader.SongData currentSong, string tagtofind, string textcolor)
+    public static List<string> CreateDisplayStringAdditions(SongDataLoader.SongData currentSong, string tagtofind)
     {
         if (currentSong.HasCustomData())
         {
             //if adding 360 tags
-            if (tagtofind == "easy360" || tagtofind == "advanced360" || tagtofind == "standard360" || tagtofind == "expert360")
+            if (tagtofind == "customExpertTags" || tagtofind == "customEasyTags" || tagtofind == "customStandardTags" || tagtofind == "customAdvancedTags")
             {
                 if (currentSong.SongHasCustomDataKey(tagtofind))
                 {
-                    if(currentSong.GetCustomData<bool>(tagtofind))
-                    {
-                        return "<color=#" + textcolor + ">(360) </color>";
-                    }
+                    List<string> customTags = currentSong.GetCustomData<List<string>>(tagtofind);
+
+             
+                    return customTags;
                 }
             }
 
             //TODO: could do more tags here
         }
 
-        return "";
+        return new List<string>();
     }
 
-    private static fillData fillAdditions(string songID, fillData d)
+    private static fillData fillAdditions(string songID, fillData d, DifficultyCalculator calc)
     {
         SongDataLoader.SongData currentSong = SongDataLoader.AllSongData[songID];
-        d.easyAdditions = CreateDisplayStringAdditions(currentSong, "easy360", "54f719");
-        d.advancedAdditions = CreateDisplayStringAdditions(currentSong, "advanced360", "f7a919");
-        d.standardAdditions = CreateDisplayStringAdditions(currentSong, "standard360", "19d2f7");
-        d.expertAdditions = CreateDisplayStringAdditions(currentSong, "expert360", "b119f7");
+        d.easyAdditions = CreateDisplayStringAdditions(currentSong, "customEasyTags");
+        d.advancedAdditions = CreateDisplayStringAdditions(currentSong, "customAdvancedTags");
+        d.standardAdditions = CreateDisplayStringAdditions(currentSong, "customStandardTags");
+        d.expertAdditions = CreateDisplayStringAdditions(currentSong, "customExpertTags");
 
         return d;
     }
@@ -101,9 +102,13 @@ internal static class DifficultyDisplay
     {
         string output = "Difficulty Rating\n";
         var songData = SongDataHolder.I.songData;
-        var calc = new DifficultyCalculator(songData);
+        var calc = SongBrowser.DiffCache.getDifficultyCalculations(songData);
 
         fillData AdditionHolder = new fillData();
+        AdditionHolder.easyAdditions = new List<string>();
+        AdditionHolder.advancedAdditions = new List<string>();
+        AdditionHolder.standardAdditions = new List<string>();
+        AdditionHolder.expertAdditions = new List<string>();
 
         if (SongBrowser.songDataLoaderInstalled)
         {
@@ -115,33 +120,46 @@ internal static class DifficultyDisplay
             CreateDisplayString() won't run. Since all mentions of Son Data Loader are in fillAdditions(), which 
             is behind a conditional we wont have that issue.
             */
-            AdditionHolder.easyAdditions = "";
-            AdditionHolder.advancedAdditions = "";
-            AdditionHolder.standardAdditions = "";
-            AdditionHolder.expertAdditions = "";
-
-            AdditionHolder = fillAdditions(songData.songID, AdditionHolder);
+           
+            AdditionHolder = fillAdditions(songData.songID, AdditionHolder, calc);
         }
+
+        //add 360 if it is
+
+        if (songData.hasEasy && calc.beginner.is360) AdditionHolder.easyAdditions.Insert(0, "360");
+
+        if (songData.hasNormal && calc.standard.is360) AdditionHolder.standardAdditions.Insert(0, "360");
+
+        if (songData.hasHard && calc.advanced.is360) AdditionHolder.advancedAdditions.Insert(0, "360");
+
+
+        if (songData.hasExpert && calc.expert.is360) AdditionHolder.expertAdditions.Insert(0, "360");
+
+        AdditionHolder.expertAdditions = AdditionHolder.expertAdditions.Distinct().ToList();
+        AdditionHolder.standardAdditions = AdditionHolder.standardAdditions.Distinct().ToList();
+        AdditionHolder.advancedAdditions = AdditionHolder.advancedAdditions.Distinct().ToList();
+        AdditionHolder.easyAdditions = AdditionHolder.easyAdditions.Distinct().ToList();
+
 
         if (calc.expert != null)
         {
-            output += $"<color=#b119f7>{calc.expert.difficultyRating.ToString("n2")}</color>  ";
-            output += AdditionHolder.expertAdditions;
+            output += $"<color=#b119f7>{calc.expert.difficultyRating.ToString("n2")} ";
+            output += AdditionHolder.expertAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.expertAdditions.ToArray()) + ")</color> " : "</color> ";
         }
         if (calc.advanced != null)
         {
-            output += $"<color=#f7a919>{calc.advanced.difficultyRating.ToString("n2")}</color>  ";
-            output += AdditionHolder.advancedAdditions;
+            output += $"<color=#f7a919>{calc.advanced.difficultyRating.ToString("n2")} ";
+            output += AdditionHolder.advancedAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.advancedAdditions.ToArray()) + ")</color> " : "</color> ";
         }
         if (calc.standard != null)
         {
-            output += $"<color=#19d2f7>{calc.standard.difficultyRating.ToString("n2")}</color>  ";
-            output += AdditionHolder.standardAdditions;
+            output += $"<color=#19d2f7>{calc.standard.difficultyRating.ToString("n2")} ";
+            output += AdditionHolder.standardAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.standardAdditions.ToArray()) + ")</color> " : "</color> ";
         }
         if (calc.beginner != null)
         {
-            output += $"<color=#54f719>{calc.beginner.difficultyRating.ToString("n2")}</color>  ";
-            output += AdditionHolder.easyAdditions;
+            output += $"<color=#54f719>{calc.beginner.difficultyRating.ToString("n2")} ";
+            output += AdditionHolder.easyAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.easyAdditions.ToArray()) + ")</color> " : "</color> ";
         }
         return output;
     }

--- a/AudicaMod/src/UI/AudicaScore/DifficultyDisplay.cs
+++ b/AudicaMod/src/UI/AudicaScore/DifficultyDisplay.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
+using static DifficultyCalculator;
 
 internal static class DifficultyDisplay
 {
@@ -123,11 +124,21 @@ internal static class DifficultyDisplay
             AdditionHolder = fillAdditions(songData.songID, AdditionHolder);
         }
 
-        (float value, bool is360) easy = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Easy.ToString());
-        (float value, bool is360) normal = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Normal.ToString());
-        (float value, bool is360) hard = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Hard.ToString());
-        (float value, bool is360) expert = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Expert.ToString());
+        CachedCalculation easy = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Easy.ToString());
+        CachedCalculation normal = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Normal.ToString());
+        CachedCalculation hard = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Hard.ToString());
+        CachedCalculation expert = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Expert.ToString());
 
+
+        //add mine tags if it has mines
+
+        if (songData.hasEasy && easy.hasMines) AdditionHolder.easyAdditions.Insert(0, "Mines");
+
+        if (songData.hasNormal && normal.hasMines) AdditionHolder.standardAdditions.Insert(0, "Mines");
+
+        if (songData.hasHard && hard.hasMines) AdditionHolder.advancedAdditions.Insert(0, "Mines");
+
+        if (songData.hasExpert && expert.hasMines) AdditionHolder.expertAdditions.Insert(0, "Mines");
 
         //add 360 if it is
 

--- a/AudicaMod/src/UI/AudicaScore/DifficultyDisplay.cs
+++ b/AudicaMod/src/UI/AudicaScore/DifficultyDisplay.cs
@@ -87,7 +87,7 @@ internal static class DifficultyDisplay
         return new List<string>();
     }
 
-    private static fillData fillAdditions(string songID, fillData d, DifficultyCalculator calc)
+    private static fillData fillAdditions(string songID, fillData d)
     {
         SongDataLoader.SongData currentSong = SongDataLoader.AllSongData[songID];
         d.easyAdditions = CreateDisplayStringAdditions(currentSong, "customEasyTags");
@@ -102,7 +102,6 @@ internal static class DifficultyDisplay
     {
         string output = "Difficulty Rating\n";
         var songData = SongDataHolder.I.songData;
-        var calc = SongBrowser.DiffCache.getDifficultyCalculations(songData);
 
         fillData AdditionHolder = new fillData();
         AdditionHolder.easyAdditions = new List<string>();
@@ -121,19 +120,24 @@ internal static class DifficultyDisplay
             is behind a conditional we wont have that issue.
             */
            
-            AdditionHolder = fillAdditions(songData.songID, AdditionHolder, calc);
+            AdditionHolder = fillAdditions(songData.songID, AdditionHolder);
         }
+
+        (float value, bool is360) easy = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Easy.ToString());
+        (float value, bool is360) normal = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Normal.ToString());
+        (float value, bool is360) hard = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Hard.ToString());
+        (float value, bool is360) expert = DifficultyCalculator.GetRating(songData.songID, KataConfig.Difficulty.Expert.ToString());
+
 
         //add 360 if it is
 
-        if (songData.hasEasy && calc.beginner.is360) AdditionHolder.easyAdditions.Insert(0, "360");
+        if (songData.hasEasy && easy.is360) AdditionHolder.easyAdditions.Insert(0, "360");
 
-        if (songData.hasNormal && calc.standard.is360) AdditionHolder.standardAdditions.Insert(0, "360");
+        if (songData.hasNormal && normal.is360) AdditionHolder.standardAdditions.Insert(0, "360");
 
-        if (songData.hasHard && calc.advanced.is360) AdditionHolder.advancedAdditions.Insert(0, "360");
+        if (songData.hasHard && hard.is360) AdditionHolder.advancedAdditions.Insert(0, "360");
 
-
-        if (songData.hasExpert && calc.expert.is360) AdditionHolder.expertAdditions.Insert(0, "360");
+        if (songData.hasExpert && expert.is360) AdditionHolder.expertAdditions.Insert(0, "360");
 
         AdditionHolder.expertAdditions = AdditionHolder.expertAdditions.Distinct().ToList();
         AdditionHolder.standardAdditions = AdditionHolder.standardAdditions.Distinct().ToList();
@@ -141,24 +145,24 @@ internal static class DifficultyDisplay
         AdditionHolder.easyAdditions = AdditionHolder.easyAdditions.Distinct().ToList();
 
 
-        if (calc.expert != null)
+        if (expert.value != 0)
         {
-            output += $"<color=#b119f7>{calc.expert.difficultyRating.ToString("n2")} ";
+            output += $"<color=#b119f7>{expert.value.ToString("n2")} ";
             output += AdditionHolder.expertAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.expertAdditions.ToArray()) + ")</color> " : "</color> ";
         }
-        if (calc.advanced != null)
+        if (hard.value != 0)
         {
-            output += $"<color=#f7a919>{calc.advanced.difficultyRating.ToString("n2")} ";
+            output += $"<color=#f7a919>{hard.value.ToString("n2")} ";
             output += AdditionHolder.advancedAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.advancedAdditions.ToArray()) + ")</color> " : "</color> ";
         }
-        if (calc.standard != null)
+        if (normal.value != 0)
         {
-            output += $"<color=#19d2f7>{calc.standard.difficultyRating.ToString("n2")} ";
+            output += $"<color=#19d2f7>{normal.value.ToString("n2")} ";
             output += AdditionHolder.standardAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.standardAdditions.ToArray()) + ")</color> " : "</color> ";
         }
-        if (calc.beginner != null)
+        if (easy.value != 0)
         {
-            output += $"<color=#54f719>{calc.beginner.difficultyRating.ToString("n2")} ";
+            output += $"<color=#54f719>{easy.value.ToString("n2")} ";
             output += AdditionHolder.easyAdditions.Count > 0 ? "(" + string.Join(", ", AdditionHolder.easyAdditions.ToArray()) + ")</color> " : "</color> ";
         }
         return output;

--- a/AudicaMod/src/UI/SongDownloaderUI.cs
+++ b/AudicaMod/src/UI/SongDownloaderUI.cs
@@ -6,6 +6,7 @@ using MelonLoader;
 using UnityEngine.UI;
 using System.Collections.Generic;
 using UnityEngine.Experimental.XR;
+using System.Linq;
 
 namespace AudicaModding
 {
@@ -235,11 +236,16 @@ namespace AudicaModding
             songd.hasAdvanced = song.advanced;
             songd.hasExpert = song.expert;
 
-            //if song data loader is installed look for 360 tag
+            //if song data loader is installed look for custom tags
             if (SongBrowser.songDataLoaderInstalled)
             {
-                songd = SongBrowser.SongDisplayPackage.Fill360Data(songd, song.song_id);
+                songd = SongBrowser.SongDisplayPackage.FillCustomData(songd, song.song_id);
             }
+
+            songd.customExpertTags = songd.customExpertTags.Distinct().ToList();
+            songd.customStandardTags = songd.customStandardTags.Distinct().ToList();
+            songd.customAdvancedTags = songd.customAdvancedTags.Distinct().ToList();
+            songd.customEasyTags = songd.customEasyTags.Distinct().ToList();
 
             var downloadButton = optionsMenu.AddButton(0,
 				"Download" + SongBrowser.GetDifficultyString(songd),


### PR DESCRIPTION
The game now calculates note span in meters. It will find the two notes that are furthest in the negative and positive x and y directions when calculating difficulties and store that data. If it detects a span in the x direction greater than 20 meters, a bool in CalculatedDifficulty will be set to true. This bool is also cached along with the difficulty rating numbers as a tuple. 


You can now also specify custom tags for songs. Here's an example:

```
"customEasyTags": [
    "these"
  ],
  "customStandardTags": [
    "are"
  ],
  "customAdvancedTags": [
    "custom",
	"for",
	"testing"
  ],
  "customExpertTags": [
    "cool",
	"stuff",
	"360",
	"^That is still valid and wont be shown twice if the game determines its 360"
  ]
```